### PR TITLE
GCO-2398: Zoekfunctionaliteit verbeteren - ook relaties meenemen in resultaten

### DIFF
--- a/src/__test__/TestData.ts
+++ b/src/__test__/TestData.ts
@@ -574,6 +574,7 @@ export const mockBindingSets: BindingSet[] = [
     begrip: namedNode('Derde begrip'),
     definition: literal('Derde definitie'),
     label: literal('Derde label'),
+    related: literal('Eerste begrip'),
   },
   {
     begrip: namedNode('Vierde begrip'),
@@ -581,4 +582,4 @@ export const mockBindingSets: BindingSet[] = [
   },
 ];
 
-export const mockBindingNames = ['begrip', 'definition', 'label'];
+export const mockBindingNames = ['begrip', 'definition', 'label', 'related'];

--- a/src/__test__/components/RefineSearchFilters.test.tsx
+++ b/src/__test__/components/RefineSearchFilters.test.tsx
@@ -1,0 +1,19 @@
+import { Filter, RefineSearchFilters } from '../../components/RefineSearchFilters';
+import { mount, shallow } from 'enzyme';
+import React from 'react';
+
+describe('<RefineSearchFilters/>', () => {
+  it('should render a select box for related search', () => {
+    const wrapper = mount(<RefineSearchFilters selected={jest.fn} availableFilters={[Filter.RELATED]}/>);
+    expect(wrapper.find('input[type="checkbox"]')).toHaveLength(1);
+  });
+
+  it('should return "RELATED" when checkbox for refined search value is checked', () => {
+    const onSelect = jest.fn();
+
+    const wrapper = shallow(<RefineSearchFilters selected={onSelect} availableFilters={[Filter.RELATED]}/>);
+
+    wrapper.find('input[type="checkbox"]').simulate('change', { target: { checked: true, name: 'RELATED' } });
+    expect(onSelect).toHaveBeenCalledWith(['RELATED']);
+  });
+});

--- a/src/__test__/components/TupleList.test.tsx
+++ b/src/__test__/components/TupleList.test.tsx
@@ -6,6 +6,7 @@ import { mockBindingNames, mockBindingSets } from '../TestData';
 import { Value, ValueProps } from '../..';
 import { Term } from 'rdf-js';
 import { SuggestProps } from '../../components/SearchInput';
+import { FilterConfig } from '../../components/RefineSearchFilters';
 
 describe('<TupleList />', () => {
   const getColumns = (): Column[] => [
@@ -19,13 +20,14 @@ describe('<TupleList />', () => {
 
   const buildTableWithRecords = (columns: Column[], pagination?: PaginationProps, valueProps?: ValueProps,
                                  suggest?: SuggestProps, search?: SearchListProps,
-                                 alphabetIndexBar?: AlphabetIndexBarProps) => {
+                                 alphabetIndexBar?: AlphabetIndexBarProps, filterConfig?: FilterConfig) => {
 
     return mount(
       <TupleList
         suggest={suggest}
         search={search}
         alphabeticIndexBar={alphabetIndexBar}
+        filterConfig={filterConfig}
         result={mockTupleResult}
         columns={columns}
         pagination={pagination}
@@ -205,5 +207,23 @@ describe('<TupleList />', () => {
     const rows = wrapper.find('table > tbody > tr');
     expect(rows).toHaveLength(1);
     expect(rows.first().find('td:first-child').text()).toBe('Eerste begrip');
+  });
+
+  it('should include related items when refined filter is enabled', () => {
+    const wrapper = buildTableWithRecords(getColumns(), { pageSize: 10 }, undefined,
+                                          undefined, { fields: ['begrip'], instant: true }, undefined,
+                                          { RELATED: { referenceField:'begrip', relatedFields: ['related'] } });
+    // simulate search input
+    wrapper.find('input[type="search"]').simulate('change', { target: { value: 'Derde' } });
+    let rows = wrapper.find('table > tbody > tr');
+    expect(rows).toHaveLength(1);
+    expect(rows.first().find('td:first-child').text()).toBe('Derde begrip');
+
+    // enable related items
+    wrapper.find('input[type="checkbox"]').simulate('change', { target: { checked: true, name: 'RELATED' } });
+    rows = wrapper.find('table > tbody > tr');
+    expect(rows).toHaveLength(2);
+    expect(rows.at(0).find('td').at(0).text()).toBe('Derde begrip');
+    expect(rows.at(1).find('td').at(0).text()).toBe('Eerste begrip');
   });
 });

--- a/src/components/RefineSearchFilters.tsx
+++ b/src/components/RefineSearchFilters.tsx
@@ -1,0 +1,49 @@
+import React, { FunctionComponent, useState } from 'react';
+import i18next from '../i18n';
+
+export enum Filter {
+    RELATED = i18next.t('relatedFilter'),
+}
+
+export type FilterConfig = {
+  RELATED?: {relatedFields: string[], referenceField: string};
+};
+
+type CustomSearchFiltersProps = {
+  availableFilters: Filter[];
+  selected: (filters: Filter[]) => void;
+};
+
+export const RefineSearchFilters: FunctionComponent<CustomSearchFiltersProps> = ({ selected, availableFilters }) => {
+  const [selectedFilters, setSelectedFilters] = useState([] as Filter[]);
+
+  const handleFilterSelect = (event: any) => {
+    const checked = event.target.checked;
+    const name = event.target.name;
+    let filters: Filter[];
+    if (checked) {
+      filters = [...selectedFilters, name];
+    } else {
+      filters = [...selectedFilters.filter(el => name !== el)];
+    }
+    setSelectedFilters(filters);
+    selected(filters);
+  };
+
+  return (
+      <div className="panel panel-default card">
+        <div className="panel-heading card-header">{i18next.t('refineResults')}
+          <span className={'glyphicon glyphicon-chevron-down'}/>
+        </div>
+        <div className="panel-body card-body">
+            {availableFilters.map((f:Filter, index:number) => (
+                <div className="checkbox" key={index}>
+                    <label>
+                        {/*@ts-ignore*/}
+                        <input type="checkbox" name={f} onChange={handleFilterSelect}/> {Filter[f]}
+                    </label>
+                </div>
+            ))}
+        </div>
+    </div>);
+};

--- a/src/examples/TupleListExample.tsx
+++ b/src/examples/TupleListExample.tsx
@@ -3,7 +3,7 @@ import TupleContext from '../components/TupleContext';
 import TupleList, { Column } from '../components/TupleList';
 import { Term } from 'rdf-js';
 
-const endpoint = 'https://stelselcatalogus.omgevingswet.overheid.nl/concepten';
+const endpoint = 'http://localhost:8080/concepten';
 
 const columns: Column[] = [
   {
@@ -29,8 +29,9 @@ export default () => (
       <TupleContext src={endpoint}>
         {result => (
               <TupleList
-            suggest={{ suggestions: [result, 'resource_label'] }}
-            search={ { fields: ['resource_label', 'uitleg'], instant: false }}
+            // suggest={{ suggestions: [result, 'resource_label'] }}
+            filterConfig={ { RELATED: { referenceField:'resource', relatedFields:['related'] } } }
+            search={ { fields: ['resource_label', 'uitleg'], instant: true }}
             alphabeticIndexBar={ { field: 'resource_label' } }
             result={result}
             columns={columns}

--- a/src/examples/TupleListExample.tsx
+++ b/src/examples/TupleListExample.tsx
@@ -3,7 +3,7 @@ import TupleContext from '../components/TupleContext';
 import TupleList, { Column } from '../components/TupleList';
 import { Term } from 'rdf-js';
 
-const endpoint = 'http://localhost:8080/concepten';
+const endpoint = 'https://stelselcatalogus.omgevingswet.overheid.nl/concepten';
 
 const columns: Column[] = [
   {
@@ -29,9 +29,9 @@ export default () => (
       <TupleContext src={endpoint}>
         {result => (
               <TupleList
-            // suggest={{ suggestions: [result, 'resource_label'] }}
+            suggest={{ suggestions: [result, 'resource_label'] }}
             filterConfig={ { RELATED: { referenceField:'resource', relatedFields:['related'] } } }
-            search={ { fields: ['resource_label', 'uitleg'], instant: true }}
+            search={ { fields: ['resource_label', 'uitleg'], instant: false }}
             alphabeticIndexBar={ { field: 'resource_label' } }
             result={result}
             columns={columns}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -28,6 +28,8 @@ const i18next = i18n
           noSuggestions: 'Geen suggesties gevonden.',
           searchPlaceholder: 'Voer een zoekterm in',
           showAll: 'toon alles',
+          relatedFilter: 'Relaties in zoekresultaten meenemen',
+          refineResults: 'Verfijn zoekresutaten',
         },
       },
       en: {
@@ -53,6 +55,8 @@ const i18next = i18n
           noSuggestions: 'No suggestions found.',
           searchPlaceholder: 'Enter a search term',
           showAll: 'show all',
+          relatedFilter: 'Include related subjects in search results',
+          refineResults: 'Refine searchresults',
         },
       },
     },

--- a/tslint.json
+++ b/tslint.json
@@ -3,7 +3,7 @@
   "rules": {
     "import-name": false,
     "prefer-template": false,
-    "no-console": true,
+    "no-console": false,
     "max-line-length": [true, 120],
     "variable-name": [true, "ban-keywords", "check-format", "allow-pascal-case"]
   }

--- a/tslint.json
+++ b/tslint.json
@@ -3,7 +3,7 @@
   "rules": {
     "import-name": false,
     "prefer-template": false,
-    "no-console": false,
+    "no-console": true,
     "max-line-length": [true, 120],
     "variable-name": [true, "ban-keywords", "check-format", "allow-pascal-case"]
   }


### PR DESCRIPTION
Nogal een Catalogus specifieke vraag. Ik heb het zo generiek mogelijk proberen op te lossen. Het probleem met de relaties is dat ze nested zijn in het model maar dat het LD endpoint een platte lijst terug geeft. Om die reden kun je aangeven welke field related fields zijn en hoe ze terug te vinden zijn in de lijst (referenceField).

Visueel is niet terug te zien in de tuple list dat het 'extra' resultaten zijn. Ze worden wel onder het related result in de lijst gedrukt. 